### PR TITLE
Add SQL query API endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ default-features = false
 version = "1.23.0"
 features = ["rt-multi-thread", "macros", "signal"]
 
+[dependencies.rusqlite]
+version = "0.26.3"
+features = ["bundled"]
+
 [dependencies.serde]
 version = "1.0.151"
 features = ["derive"]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -42,9 +42,9 @@ pub mod adapter;
 pub mod docs;
 pub mod files;
 mod locale;
+mod query;
 pub mod rev;
 pub mod tables;
-mod query;
 
 #[derive(Clone, Debug)]
 pub struct PercentDecoded(pub String);
@@ -182,7 +182,9 @@ impl<'r> ApiRoute<'r> {
                 },
             },
             Some("query") => match parts.next() {
-                Some(query) => Ok(Self::Query(PercentDecoded::from_str(query).map_err(|_e| ())?)),
+                Some(query) => Ok(Self::Query(
+                    PercentDecoded::from_str(query).map_err(|_e| ())?,
+                )),
                 None => Err(()),
             },
             Some("locale") => Ok(Self::Locale(RestPath(parts))),
@@ -423,7 +425,11 @@ impl ApiService {
         &self,
         f: impl FnOnce(&Path) -> Result<String, rusqlite::Error>,
     ) -> Result<Response<hyper::Body>, ApiError> {
-        Ok(reply_string(f(&self.sqlite_path)?, TEXT_CSV, StatusCode::OK))
+        Ok(reply_string(
+            f(&self.sqlite_path)?,
+            TEXT_CSV,
+            StatusCode::OK,
+        ))
     }
 
     /// Get data from `locale.xml`

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -1,9 +1,6 @@
-use std::{
-    borrow::Borrow,
-    path::Path,
-};
+use std::{borrow::Borrow, path::Path};
 
-use rusqlite::{Connection, OpenFlags, types::ValueRef};
+use rusqlite::{types::ValueRef, Connection, OpenFlags};
 
 use super::PercentDecoded;
 
@@ -14,9 +11,13 @@ fn fmt_valueref(str: &mut String, valueref: &ValueRef) -> Result<(), rusqlite::E
         ValueRef::Real(x) => str.push_str(&x.to_string()),
         ValueRef::Text(x) | ValueRef::Blob(x) => {
             str.push('"');
-            str.push_str(&std::str::from_utf8(*x).map_err(|e| rusqlite::Error::Utf8Error(e))?.replace("\"", "\"\""));
+            str.push_str(
+                &std::str::from_utf8(*x)
+                    .map_err(|e| rusqlite::Error::Utf8Error(e))?
+                    .replace("\"", "\"\""),
+            );
             str.push('"');
-        },
+        }
     }
     Ok(())
 }
@@ -37,11 +38,11 @@ pub(super) fn query<'a>(
     let mut rows = stmt.query([])?;
 
     while let Some(row) = rows.next()? {
-        for i in 0..(cols-1) {
+        for i in 0..(cols - 1) {
             fmt_valueref(&mut response, &row.get_ref(i)?)?;
             response.push(',');
         }
-        fmt_valueref(&mut response, &row.get_ref(cols-1)?)?;
+        fmt_valueref(&mut response, &row.get_ref(cols - 1)?)?;
         response.push('\n');
     }
     Ok(response)

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -22,10 +22,7 @@ fn fmt_valueref(str: &mut String, valueref: &ValueRef) -> Result<(), rusqlite::E
     Ok(())
 }
 
-pub(super) fn query(
-    sqlite_path: &Path,
-    query: PercentDecoded,
-) -> Result<String, rusqlite::Error> {
+pub(super) fn query(sqlite_path: &Path, query: PercentDecoded) -> Result<String, rusqlite::Error> {
     dbg!(&query);
     let conn = Connection::open_with_flags(sqlite_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
     let mut stmt = conn.prepare(query.borrow())?;

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -1,0 +1,48 @@
+use std::{
+    borrow::Borrow,
+    path::Path,
+};
+
+use rusqlite::{Connection, OpenFlags, types::ValueRef};
+
+use super::PercentDecoded;
+
+fn fmt_valueref(str: &mut String, valueref: &ValueRef) -> Result<(), rusqlite::Error> {
+    match valueref {
+        ValueRef::Null => str.push_str("null"),
+        ValueRef::Integer(x) => str.push_str(&x.to_string()),
+        ValueRef::Real(x) => str.push_str(&x.to_string()),
+        ValueRef::Text(x) | ValueRef::Blob(x) => {
+            str.push('"');
+            str.push_str(&std::str::from_utf8(*x).map_err(|e| rusqlite::Error::Utf8Error(e))?.replace("\"", "\"\""));
+            str.push('"');
+        },
+    }
+    Ok(())
+}
+
+pub(super) fn query<'a>(
+    sqlite_path: &Path,
+    query: PercentDecoded,
+) -> Result<String, rusqlite::Error> {
+    dbg!(&query);
+    let conn = Connection::open_with_flags(sqlite_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let mut stmt = conn.prepare(query.borrow())?;
+
+    let cols = stmt.column_count();
+    let mut response = String::new();
+    response.push_str(&stmt.column_names().join(","));
+    response.push_str("\n");
+
+    let mut rows = stmt.query([])?;
+
+    while let Some(row) = rows.next()? {
+        for i in 0..(cols-1) {
+            fmt_valueref(&mut response, &row.get_ref(i)?)?;
+            response.push(',');
+        }
+        fmt_valueref(&mut response, &row.get_ref(cols-1)?)?;
+        response.push('\n');
+    }
+    Ok(response)
+}

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -12,9 +12,9 @@ fn fmt_valueref(str: &mut String, valueref: &ValueRef) -> Result<(), rusqlite::E
         ValueRef::Text(x) | ValueRef::Blob(x) => {
             str.push('"');
             str.push_str(
-                &std::str::from_utf8(*x)
-                    .map_err(|e| rusqlite::Error::Utf8Error(e))?
-                    .replace("\"", "\"\""),
+                &std::str::from_utf8(x)
+                    .map_err(rusqlite::Error::Utf8Error)?
+                    .replace('"', "\"\""),
             );
             str.push('"');
         }
@@ -22,7 +22,7 @@ fn fmt_valueref(str: &mut String, valueref: &ValueRef) -> Result<(), rusqlite::E
     Ok(())
 }
 
-pub(super) fn query<'a>(
+pub(super) fn query(
     sqlite_path: &Path,
     query: PercentDecoded,
 ) -> Result<String, rusqlite::Error> {
@@ -33,7 +33,7 @@ pub(super) fn query<'a>(
     let cols = stmt.column_count();
     let mut response = String::new();
     response.push_str(&stmt.column_names().join(","));
-    response.push_str("\n");
+    response.push('\n');
 
     let mut rows = stmt.query([])?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,6 +160,8 @@ pub struct DataOptions {
     pub lu_res_prefix: Option<String>,
     /// The locale.xml file
     pub locale: PathBuf,
+    /// The sqlite file to serve SQL queries from
+    pub sqlite: PathBuf,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
The added /api/v0/query/<SQL> endpoint accepts arbitrary read-only SQL queries, executes them, and returns the result in CSV format.

This flexibility allows for future frontend development to proceed with no backend changes needed, and the expressiveness of SQL allows for a number of optimizations that weren't possible before.

As the game data is public already, there is no concern about SQL injection. For future content dev, the HTTP basic auth ensures that there is either no access (unauthorized) or full access (content dev).

I chose to use the GET method for this as QUERY is still nonstandard and not well supported by either the firefox devtools or the angular proxy.