### PR TITLE
Add POST support to graphQL for standards compliance

### DIFF
--- a/src/api/graphql.rs
+++ b/src/api/graphql.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Write;
-use std::{borrow::Borrow, path::Path};
+use std::path::Path;
 
 use rusqlite::{types::ValueRef, Connection, OpenFlags};
 
@@ -10,8 +10,6 @@ use graphql_parser::{
     parse_query,
     query::{Definition, Field, OperationDefinition, Selection},
 };
-
-use super::PercentDecoded;
 
 #[derive(Debug)]
 pub struct QueryError {
@@ -162,9 +160,9 @@ pub fn read_out_table_rels(sqlite_path: &Path) -> Result<TableRels, rusqlite::Er
 pub(super) fn graphql(
     sqlite_path: &Path,
     table_rels: &TableRels,
-    query: PercentDecoded,
+    query: &str,
 ) -> Result<String, QueryError> {
-    let doc = parse_query::<String>(query.borrow())?;
+    let doc = parse_query::<String>(query)?;
 
     let def = match doc.definitions.len() {
         0 => {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -443,11 +443,7 @@ impl ApiService {
         &self,
         f: impl FnOnce(&Path) -> Result<String, rusqlite::Error>,
     ) -> Result<Response<hyper::Body>, ApiError> {
-        Ok(reply_string(
-            f(self.sqlite_path)?,
-            TEXT_CSV,
-            StatusCode::OK,
-        ))
+        Ok(reply_string(f(self.sqlite_path)?, TEXT_CSV, StatusCode::OK))
     }
 
     fn graphql_api(

--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -14,7 +14,12 @@ impl CorsLayerExt<CorsOptions> for CorsLayer {
     fn configure(cfg: &CorsOptions) -> Self {
         Self::new()
             .allow_headers([AUTHORIZATION])
-            .allow_methods([Method::OPTIONS, Method::GET, METHOD_QUERY.clone()])
+            .allow_methods([
+                Method::OPTIONS,
+                Method::GET,
+                Method::POST,
+                METHOD_QUERY.clone(),
+            ])
             .allow_origin(match cfg.all {
                 true => AllowOrigin::any(),
                 false => AllowOrigin::list(cfg.domains.clone()),


### PR DESCRIPTION
This way you can use e.g. GraphiQL as a frontend