### PR TITLE
Add a script to autogenerate a GraphQL schema file describing the GraphQL API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "argh"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +949,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 name = "paradox-server"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "assembly-core",
  "assembly-fdb",
  "assembly-pack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,17 @@ version = "0.1.0"
 authors = ["Xiphoseer <xiphoseer@mailbox.org>"]
 edition = "2018"
 
+[features]
+sqlite-to-graphql-schema = ["argh"]
+
+[[example]]
+name = "sqlite-to-graphql-schema"
+required-features = ["sqlite-to-graphql-schema"]
+
+[dependencies.argh]
+version = "0.1.9"
+optional = true
+
 [dependencies.assembly-core]
 version = "0.3.1"
 

--- a/examples/sqlite-to-graphql-schema.rs
+++ b/examples/sqlite-to-graphql-schema.rs
@@ -1,0 +1,143 @@
+use std::{collections::HashMap, fmt::Write, path::PathBuf, time::Instant};
+
+use argh::FromArgs;
+use color_eyre::eyre::WrapErr;
+use rusqlite::Connection;
+
+#[derive(FromArgs)]
+/// Outputs a GraphQL schema file based on the schema of the SQLite database
+struct Options {
+    /// input SQLite file
+    #[argh(positional)]
+    src: PathBuf,
+    /// the GraphQL schema output file
+    #[argh(positional)]
+    dest: PathBuf,
+}
+
+fn to_gql_type(sql_type: &str) -> String {
+    String::from(match sql_type {
+        "INTEGER" | "INT32" | "INT64" | "INT_BOOL" => "Int",
+        "TEXT4" | "TEXT_XML" | "BLOB_NONE" => "String",
+        "REAL" => "Float",
+        _ => todo!(),
+    })
+}
+
+fn try_export_db(conn: &mut Connection) -> color_eyre::Result<String> {
+    let mut out = String::from("schema {\n\tquery: Query\n}\n\n");
+
+    let mut tables_stmt = conn.prepare("select m.name, c.name, c.type, c.\"notnull\", fk.\"table\" from sqlite_master m join pragma_table_info(m.name) c left join pragma_foreign_key_list(m.name) fk on c.name == fk.\"from\"")?;
+    let mut tables_rows = tables_stmt.query([])?;
+
+    let mut table_rels: HashMap<String, Vec<(String, bool)>> = HashMap::new();
+    let mut rev_rels: HashMap<String, Vec<String>> = HashMap::new();
+    let mut last_table = String::new();
+
+    while let Some(tables_row) = tables_rows.next()? {
+        let table_name: String = tables_row.get(0)?;
+        let col_name: String = tables_row.get(1)?;
+        let col_type: String = tables_row.get(2)?;
+        let col_type = to_gql_type(&col_type);
+        let not_null: bool = tables_row.get(3)?;
+        let fk_table: Option<String> = tables_row.get(4)?;
+
+        if table_name != last_table {
+            for (other_table, rels) in rev_rels {
+                let t_rels = table_rels.entry(other_table).or_default();
+                if rels.len() == 1 {
+                    if let Some(col) = rels.iter().next() {
+                        t_rels.push((
+                            format!(
+                                "{}: {}",
+                                &col[..col.find("_").unwrap()],
+                                &col[col.find(":").unwrap() + 2..]
+                            ),
+                            true,
+                        ));
+                    }
+                }
+                for col in rels {
+                    t_rels.push((col, true));
+                }
+            }
+            rev_rels = HashMap::new();
+            last_table = table_name.clone();
+        }
+
+        let tbl = table_rels.entry(table_name.clone()).or_default();
+
+        let mut col_ty = String::new();
+        write!(
+            col_ty,
+            "{}",
+            if let Some(ref x) = fk_table {
+                &x
+            } else {
+                &col_type
+            }
+        )?;
+        if col_name.ends_with("_en_US") {
+            let mut loc_name = col_name.clone();
+            loc_name.truncate(loc_name.len() - "en_US".len());
+            loc_name.push_str("loc");
+            tbl.push((format!("{}: {}", loc_name, col_ty), not_null));
+        }
+        if let Some(x) = fk_table {
+            let rev_col = format!("{}_{}", table_name, col_name);
+
+            rev_rels
+                .entry(x.clone())
+                .or_default()
+                .push(format!("{}: [{}!]", rev_col, table_name));
+        }
+        tbl.push((format!("{}: {}", col_name, col_ty), not_null));
+    }
+    for (table_name, cols) in &table_rels {
+        write!(out, "type {} {{\n", table_name)?;
+        for (col_ty, not_null) in cols {
+            write!(out, "\t{}", col_ty)?;
+            if *not_null {
+                write!(out, "!")?;
+            }
+            write!(out, "\n")?;
+        }
+        write!(out, "}}\n\n")?;
+    }
+    write!(
+        out,
+        "type Query {{\n\t{}\n}}",
+        table_rels
+            .into_iter()
+            .map(|(k, v)| format!(
+                "{}({}): [{}]",
+                k,
+                v.into_iter().map(|x| x.0).collect::<Vec<_>>().join(", "),
+                k
+            ))
+            .collect::<Vec<_>>()
+            .join("\n\t")
+    )?;
+    Ok(out)
+}
+
+fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+    let opts: Options = argh::from_env();
+    let start = Instant::now();
+
+    let mut conn = Connection::open(opts.src)?;
+
+    let out = try_export_db(&mut conn).wrap_err("Failed to export database to sqlite")?;
+
+    std::fs::write(opts.dest, out)?;
+
+    let duration = start.elapsed();
+    println!(
+        "Finished in {}.{}s",
+        duration.as_secs(),
+        duration.subsec_millis()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This GraphQL schema file can then later be used by downstream tools for e.g. code generation and typing of GraphQL queries.